### PR TITLE
refactor: SQLAlchemy ORM で CRUD を書き直す (phase 6)

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -4,7 +4,7 @@ from flask import Flask
 from dotenv import load_dotenv
 
 from app.config import config
-from app import db
+from app.db import db, init_app as db_init_app
 
 
 def create_app(config_name: Optional[str] = None) -> Flask:
@@ -35,10 +35,16 @@ def create_app(config_name: Optional[str] = None) -> Flask:
     # JSON レスポンスで日本語を文字化けさせない
     app.json.ensure_ascii = False
 
-    # DB 初期化フックを登録
-    db.init_app(app)
+    # SQLAlchemy を Flask アプリに紐づけ、CLI コマンドを登録する
+    db_init_app(app)
 
-    # Blueprint の登録（Phase 4 で追加する）
+    # モデルモジュールを import することで db.create_all() がテーブルを認識できる。
+    # ローカル変数 app（Flask インスタンス）と名前が衝突しないよう from 形式で書く。
+    # _models に束ねることで「副作用目的の import」であることを明示し、
+    # IDE の「未参照」ヒントも抑制する。
+    from app import models as _models
+    _ = _models
+
     from app.routes.auth import auth_bp
     from app.routes.diary import diary_bp
 

--- a/app/config.py
+++ b/app/config.py
@@ -1,10 +1,20 @@
 import os
 
+_BASE_DIR = os.path.dirname(os.path.dirname(__file__))
+_DB_PATH = os.path.join(_BASE_DIR, "instance", "diary.db")
+
 
 class Config:
     """全環境共通の設定基底クラス。"""
     SECRET_KEY = os.environ.get("SECRET_KEY", "dev-fallback-key-change-in-production")
-    DATABASE = os.path.join(os.path.dirname(os.path.dirname(__file__)), "instance", "diary.db")
+
+    # SQLAlchemy が接続先を判断するための URI。
+    # SQLite の場合は "sqlite:///絶対パス" の形式になる（スラッシュが3つ）。
+    SQLALCHEMY_DATABASE_URI = f"sqlite:///{_DB_PATH}"
+
+    # SQLAlchemy がモデルの変更を追跡する機能（不要なためオフ）。
+    # True にするとメモリを余分に使うので、明示的に False を設定しておく。
+    SQLALCHEMY_TRACK_MODIFICATIONS = False
 
 
 class DevelopmentConfig(Config):
@@ -15,7 +25,9 @@ class DevelopmentConfig(Config):
 class TestingConfig(Config):
     """テスト環境の設定。インメモリ DB を使用する。"""
     TESTING = True
-    DATABASE = ":memory:"
+    # テスト用インメモリ DB の URI。
+    # "sqlite:///:memory:" は接続を閉じると DB が消える揮発的な SQLite DB。
+    SQLALCHEMY_DATABASE_URI = "sqlite:///:memory:"
 
 
 class ProductionConfig(Config):

--- a/app/db.py
+++ b/app/db.py
@@ -1,73 +1,19 @@
-import sqlite3
-import os
 import click
-from flask import current_app, g
+from flask_sqlalchemy import SQLAlchemy
 
-
-def get_db():
-    """現在のリクエストに紐づいた DB 接続を返す。
-
-    Flask の g オブジェクトに接続をキャッシュすることで、
-    1リクエスト内で get_db() を複数回呼んでも接続は1本のみになる。
-    """
-    if "db" not in g:
-        db_path = current_app.config["DATABASE"]
-
-        # テスト用のインメモリ DB でなければ、ディレクトリを作成する
-        if db_path != ":memory:":
-            os.makedirs(os.path.dirname(db_path), exist_ok=True)
-
-        g.db = sqlite3.connect(db_path)
-
-        # カラム名でアクセスできるように Row ファクトリを設定する
-        # 例: row["email"] のようにアクセスできる
-        g.db.row_factory = sqlite3.Row
-
-        # 外部キー制約を有効化（SQLite はデフォルトで無効）
-        g.db.execute("PRAGMA foreign_keys = ON")
-
-        # WAL モード: 読み取りと書き込みを並行して行えるようにする
-        g.db.execute("PRAGMA journal_mode = WAL")
-
-    return g.db
-
-
-def close_db(e=None):
-    """リクエスト終了時に DB 接続を閉じる。
-
-    Flask の teardown_appcontext に登録することで、
-    リクエストの完了（正常・エラー問わず）に自動で呼ばれる。
-    """
-    db = g.pop("db", None)
-    if db is not None:
-        db.close()
+# SQLAlchemy のシングルトンインスタンス。
+# このオブジェクトを models/ でインポートして db.Model を継承する。
+# create_app() で db.init_app(app) を呼ぶことで Flask アプリに紐づく。
+db = SQLAlchemy()
 
 
 def init_db():
-    """データベーススキーマを初期化（テーブルが存在しない場合のみ作成）する。"""
-    db = get_db()
-    db.executescript("""
-        CREATE TABLE IF NOT EXISTS users (
-            id           INTEGER PRIMARY KEY AUTOINCREMENT,
-            username     TEXT    NOT NULL,
-            email        TEXT    NOT NULL UNIQUE,
-            password_hash TEXT   NOT NULL,
-            created_at   TEXT    NOT NULL DEFAULT (datetime('now', 'localtime'))
-        );
+    """テーブルが存在しない場合のみ全テーブルを作成する。
 
-        CREATE TABLE IF NOT EXISTS diaries (
-            id         INTEGER PRIMARY KEY AUTOINCREMENT,
-            user_id    INTEGER NOT NULL,
-            title      TEXT    NOT NULL,
-            comment    TEXT    NOT NULL,
-            created_at TEXT    NOT NULL DEFAULT (datetime('now', 'localtime')),
-            FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
-        );
-
-        CREATE INDEX IF NOT EXISTS idx_diaries_user_id    ON diaries(user_id);
-        CREATE INDEX IF NOT EXISTS idx_diaries_created_at ON diaries(created_at);
-    """)
-    db.commit()
+    SQLAlchemy は db.Model を継承したクラスの Column 定義から
+    CREATE TABLE 文を自動生成する（スキーマを Python コードで宣言的に管理できる）。
+    """
+    db.create_all()
 
 
 @click.command("init-db")
@@ -78,12 +24,12 @@ def init_db_command():
 
 
 def init_app(app):
-    """Flask アプリに DB 関連のフックを登録する。
+    """Flask アプリに SQLAlchemy を紐づけ、CLI コマンドを登録する。
 
-    create_app() から呼ばれることを前提としている。
+    db.init_app(app) は「このアプリを使うときは app.config の
+    SQLALCHEMY_DATABASE_URI に接続せよ」と SQLAlchemy に伝える処理。
+    接続のライフサイクル管理（リクエスト終了時のクローズ等）は
+    Flask-SQLAlchemy が自動で行うため、teardown_appcontext の手動登録は不要になる。
     """
-    # リクエスト終了時に close_db が自動で呼ばれるよう登録
-    app.teardown_appcontext(close_db)
-
-    # `flask init-db` コマンドを CLI に追加
+    db.init_app(app)
     app.cli.add_command(init_db_command)

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,0 +1,6 @@
+# このファイルを import するだけで User・DiaryEntry が SQLAlchemy に登録される。
+# db.create_all() はここで import されたモデルクラスを元にテーブルを生成する。
+from app.models.user import User
+from app.models.diary import DiaryEntry
+
+__all__ = ["User", "DiaryEntry"]

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -1,75 +1,105 @@
-from dataclasses import dataclass
-from typing import Optional
-from app.db import get_db
+from typing import Optional, List
+from sqlalchemy import String, Text
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.db import db
 
 
-@dataclass
-class User:
-    """users テーブルの1行を表すデータクラス。
+class User(db.Model):
+    """users テーブルの ORM モデル。
 
-    dataclass を使うと __init__・__repr__ が自動生成される。
-    モデルは「データ構造 + DB アクセス」のみを担当する。
+    ## ORM とは
+    ORM（Object-Relational Mapper）は DB のテーブル行を Python オブジェクトとして
+    扱う仕組み。SQL 文字列の代わりに Python のメソッド呼び出しで CRUD を行う。
+
+    ## db.Model 継承
+    Flask-SQLAlchemy が提供する基底クラス。継承するだけでテーブルと紐づく。
+    クラス名（User）が自動的にテーブル名（users）にスネークケース変換される。
+
+    ## Mapped / mapped_column（SQLAlchemy 2.0 スタイル）
+    `Mapped[型]` で型ヒントを付けながらカラムを宣言する新しい書き方。
+    `mapped_column()` はカラムの制約（PRIMARY KEY・UNIQUE・nullable など）を指定する。
     """
-    id: int
-    username: str
-    email: str
-    password_hash: str
-    created_at: str
+
+    __tablename__ = "users"
+
+    # primary_key=True で AUTOINCREMENT な主キーになる。
+    # SQLAlchemy が INSERT 後に DB 生成の id を自動でオブジェクトに反映する。
+    id: Mapped[int] = mapped_column(primary_key=True)
+    username: Mapped[str] = mapped_column(String(100), nullable=False)
+    email: Mapped[str] = mapped_column(String(254), nullable=False, unique=True)
+    password_hash: Mapped[str] = mapped_column(Text, nullable=False)
+
+    # server_default: INSERT 時に DB 側でデフォルト値を設定する。
+    # Python 側での指定は不要で、commit 後に DB から値が反映される。
+    created_at: Mapped[str] = mapped_column(
+        String(30),
+        nullable=False,
+        server_default="(datetime('now', 'localtime'))",
+    )
+
+    # relationship: 外部キーを介した関連オブジェクトへのアクセスを定義する。
+    # cascade="all, delete-orphan" = User を削除したら紐づく DiaryEntry も削除する。
+    # back_populates で双方向の関連を張り、DiaryEntry.user からも User に辿れる。
+    # lazy="select" = relationship に最初にアクセスした時点で SELECT を発行する（遅延ロード）。
+    diaries: Mapped[List["DiaryEntry"]] = relationship(  # type: ignore[name-defined]
+        "DiaryEntry",
+        back_populates="user",
+        cascade="all, delete-orphan",
+        lazy="select",
+    )
+
+    # ---- クラスメソッド（ファクトリ） ----------------------------------------
 
     @classmethod
-    def from_row(cls, row) -> "User":
-        """sqlite3.Row オブジェクトから User インスタンスを生成する。
+    def find_by_email(cls, email: str) -> Optional["User"]:
+        """メールアドレスでユーザーを検索する。存在しなければ None を返す。
 
-        sqlite3.Row はカラム名でアクセスできる辞書ライクなオブジェクト。
+        ## db.session.scalar()
+        クエリを実行して最初の1件を返す。0件なら None。
+        SQLAlchemy 2.0 では `db.select(Model).where(...)` で SELECT 文を構築し、
+        `db.session.scalar()` / `scalars()` で実行するスタイルが推奨されている。
         """
-        return cls(
-            id=row["id"],
-            username=row["username"],
-            email=row["email"],
-            password_hash=row["password_hash"],
-            created_at=row["created_at"],
+        return db.session.scalar(
+            db.select(cls).where(cls.email == email)
         )
 
-    @staticmethod
-    def find_by_email(email: str) -> Optional["User"]:
-        """メールアドレスでユーザーを検索する。存在しなければ None を返す。"""
-        db = get_db()
-        row = db.execute(
-            "SELECT * FROM users WHERE email = ?",
-            (email,)
-        ).fetchone()
-        return User.from_row(row) if row else None
+    @classmethod
+    def find_by_id(cls, user_id: int) -> Optional["User"]:
+        """ID でユーザーを検索する。存在しなければ None を返す。
 
-    @staticmethod
-    def find_by_id(user_id: int) -> Optional["User"]:
-        """ID でユーザーを検索する。存在しなければ None を返す。"""
-        db = get_db()
-        row = db.execute(
-            "SELECT * FROM users WHERE id = ?",
-            (user_id,)
-        ).fetchone()
-        return User.from_row(row) if row else None
-
-    @staticmethod
-    def create(username: str, email: str, password_hash: str) -> "User":
-        """新しいユーザーを DB に挿入し、作成した User を返す。
-
-        INSERT 後に RETURNING 句または lastrowid で生成された ID を取得する。
+        ## db.session.get()
+        PRIMARY KEY による検索に特化したメソッド。
+        同一セッション内でキャッシュ（identity map）が効くため、
+        同じ ID を2回 get() しても SQL は1度しか発行されない。
         """
-        db = get_db()
-        cursor = db.execute(
-            "INSERT INTO users (username, email, password_hash) VALUES (?, ?, ?)",
-            (username, email, password_hash),
-        )
-        db.commit()
-        user = User.find_by_id(cursor.lastrowid)
-        if user is None:
-            raise RuntimeError("Failed to retrieve created user")
+        return db.session.get(cls, user_id)
+
+    @classmethod
+    def create(cls, username: str, email: str, password_hash: str) -> "User":
+        """新しいユーザーを DB に保存して返す。
+
+        ## db.session の add / commit
+        - `db.session.add(obj)`: オブジェクトをセッションに「追跡対象」として登録する。
+          この時点では DB にはまだ書き込まれない。
+        - `db.session.commit()`: セッション内の変更をまとめて DB に書き込む（トランザクション確定）。
+          commit 後、SQLAlchemy は DB が生成した id や server_default 値を自動でオブジェクトに反映する。
+        """
+        user = cls(username=username, email=email, password_hash=password_hash)
+        db.session.add(user)
+        db.session.commit()
         return user
 
-    @staticmethod
-    def delete(user_id: int) -> None:
-        """ユーザーを削除する。ON DELETE CASCADE で関連する日記も自動削除される。"""
-        db = get_db()
-        db.execute("DELETE FROM users WHERE id = ?", (user_id,))
-        db.commit()
+    @classmethod
+    def delete(cls, user_id: int) -> None:
+        """ユーザーを削除する。cascade により日記も自動削除される。
+
+        ## db.session.delete()
+        オブジェクトを「削除予定」としてセッションに登録し、commit でDELETE を発行する。
+        relationship に cascade="all, delete-orphan" を設定しているため、
+        SQLAlchemy が DiaryEntry の DELETE を自動で先に実行する。
+        """
+        user = db.session.get(cls, user_id)
+        if user is not None:
+            db.session.delete(user)
+            db.session.commit()

--- a/app/routes/auth.py
+++ b/app/routes/auth.py
@@ -1,6 +1,5 @@
 from flask import Blueprint, render_template, redirect, request, session, flash
 
-from app.db import init_db
 from app.services.auth_service import (
     register_user,
     authenticate_user,
@@ -95,8 +94,6 @@ def register():
         return redirect("/signup")
 
     try:
-        # DB が未初期化の場合（初回起動時）に備えて init_db を呼ぶ
-        init_db()
         user = register_user(username, email, password)
     except EmailAlreadyExistsError:
         flash("このメールアドレスは既に登録されています。")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,12 @@
 blinker==1.9.0
 click==8.1.8
 Flask==3.1.3
+Flask-SQLAlchemy==3.1.1
 importlib_metadata==8.7.1
 itsdangerous==2.2.0
 Jinja2==3.1.6
 MarkupSafe==3.0.3
 python-dotenv==1.2.1
+SQLAlchemy==2.0.40
 Werkzeug==3.1.6
 zipp==3.23.0


### PR DESCRIPTION
## 変更の概要

`app/models/` の生 `sqlite3` による CRUD を Flask-SQLAlchemy ORM に書き直した。
routes・services・templates は変更なし。テスト 25 件全パス。

Closes #7

---

## なぜ ORM に移行するのか

| 観点 | 生 sqlite3 | SQLAlchemy ORM |
|------|-----------|----------------|
| SQL | 文字列で手書き → タイポでランタイムエラー | Python 式で記述 → IDE 補完・型チェックが効く |
| スキーマ定義 | `db.py` に SQL 文字列で書く | モデルクラスの `Column` 定義から自動生成 |
| 関連データ | JOIN を手書き | `relationship` で `user.diaries` のようにアクセス |
| テスト | `init_db()` でスキーマ適用 | `db.create_all()` / `db.drop_all()` で管理 |

---

## コミット構成

### 1. `chore: add Flask-SQLAlchemy, replace sqlite3 db module`

**変更ファイル:** `requirements.txt` / `app/db.py` / `app/config.py`

**`app/db.py` — SQLAlchemy インスタンスの作り方**

```python
from flask_sqlalchemy import SQLAlchemy

db = SQLAlchemy()  # まだどの Flask アプリにも紐づいていない「素の」インスタンス
```

`db` はモジュールレベルのシングルトン。モデルファイルでこれを `from app.db import db` でインポートし `db.Model` を継承することで、どのテーブルかを SQLAlchemy に教える。

Flask アプリへの紐づけは `create_app()` の中で行う：

```python
db.init_app(app)  # "このアプリの SQLALCHEMY_DATABASE_URI を使え" と伝える
```

**`app/config.py` — URI フォーマット**

```python
# sqlite:/// の後にファイルの絶対パスを続ける（スラッシュが3つ）
SQLALCHEMY_DATABASE_URI = f"sqlite:///{_DB_PATH}"

# テスト用インメモリ DB
SQLALCHEMY_DATABASE_URI = "sqlite:///:memory:"
```

---

### 2. `refactor(models): rewrite User/DiaryEntry as SQLAlchemy ORM models`

**変更ファイル:** `app/models/user.py` / `app/models/diary.py` / `app/models/__init__.py`

#### db.Model の継承

```python
class User(db.Model):
    __tablename__ = "users"
    ...
```

`db.Model` を継承するだけで SQLAlchemy がこのクラスを「テーブルと対応するモデル」として認識する。`__tablename__` でテーブル名を指定する（省略するとクラス名からスネークケースで自動推論される）。

#### Mapped / mapped_column（SQLAlchemy 2.0 スタイル）

```python
# 旧スタイル（1.x）
id = Column(Integer, primary_key=True)

# 新スタイル（2.0）
id: Mapped[int] = mapped_column(primary_key=True)
```

`Mapped[int]` という型ヒントを付けることで IDE が `user.id` の型を `int` として認識できる。`mapped_column()` の引数でカラムの制約（`primary_key` / `nullable` / `unique` / `server_default` など）を指定する。

#### server_default（DB 側のデフォルト値）

```python
created_at: Mapped[str] = mapped_column(
    String(30),
    server_default="(datetime('now', 'localtime'))",
)
```

`server_default` は INSERT 時に DB が値を自動で設定する。Python 側では何も渡さなくてよく、`commit()` 後に SQLAlchemy が DB から実際の値を取得してオブジェクトに反映する。

#### relationship（テーブル間の関連）

```python
# User モデル側
diaries: Mapped[List["DiaryEntry"]] = relationship(
    "DiaryEntry",
    back_populates="user",
    cascade="all, delete-orphan",  # User 削除時に日記も削除
)

# DiaryEntry モデル側
user: Mapped["User"] = relationship("User", back_populates="diaries")
```

`relationship` を定義することで、SQL の JOIN を書かずに関連オブジェクトにアクセスできる：

```python
user = User.find_by_id(1)
print(user.diaries)  # → SELECT diaries WHERE user_id=1 が自動で発行される
```

`back_populates` で双方向にリンクしておくと、片方を変更した時にもう片方も自動で同期される。

#### CRUD の書き方の比較

```python
# ---- 生 sqlite3 ----
cursor = db.execute("INSERT INTO users (...) VALUES (?, ?, ?)", (...))
db.commit()
row = db.execute("SELECT * FROM users WHERE id = ?", (cursor.lastrowid,)).fetchone()
return User.from_row(row)

# ---- SQLAlchemy ORM ----
user = User(username=username, email=email, password_hash=password_hash)
db.session.add(user)   # セッションに追跡対象として登録
db.session.commit()    # DB に書き込む。commit 後 user.id が自動で設定される
return user
```

**db.session** は「1リクエスト（またはテスト）中の作業単位」。変更をまとめて `commit()` で確定し、失敗したら `rollback()` で巻き戻す。Flask-SQLAlchemy がリクエスト終了時に自動でクリーンアップする。

**SELECT の書き方**

```python
# find_by_email
db.session.scalar(db.select(User).where(User.email == email))
# → SELECT * FROM users WHERE email = ? LIMIT 1

# find_by_id（primary key 専用・キャッシュ有効）
db.session.get(User, user_id)
# → SELECT * FROM users WHERE id = ?（同一セッション内は再 SELECT しない）

# list_by_user（複数件）
db.session.scalars(
    db.select(DiaryEntry)
    .where(DiaryEntry.user_id == user_id)
    .order_by(DiaryEntry.created_at.desc(), DiaryEntry.id.desc())
).all()
```

`db.select(Model)` で SELECT 文オブジェクトを作り、`.where()` / `.order_by()` でチェーンしてから `db.session.scalar()` / `scalars()` で実行する。

---

### 3. `refactor(app): wire SQLAlchemy into app factory and update fixtures`

**`app/models/__init__.py` — なぜここでインポートするか**

```python
from app.models.user import User
from app.models.diary import DiaryEntry
```

SQLAlchemy は `db.create_all()` を呼んだ時点で「今まで import されたモデルクラス」だけを対象にテーブルを作る。`models/__init__.py` でまとめてインポートしておくことで、`from app import models` の1行で全モデルが登録される。

**`tests/conftest.py` — ORM テストの初期化**

```python
@pytest.fixture
def app():
    app = create_app("testing")
    with app.app_context():
        db.create_all()   # モデルからテーブルを生成
        yield app
        db.drop_all()     # テスト後に全テーブルを削除
```

`drop_all()` → `create_all()` をテストごとに繰り返すことで、各テストが完全に独立したデータを持つことを保証する。インメモリ DB はテスト間でセッションが同じなので `drop_all()` がないとデータが残ってしまう。

---

## テスト結果

```
25 passed in 7.20s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)